### PR TITLE
Release Candidate v1.0.0-alpha.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,12 @@ jobs:
 
       - name: Publish @nuntly/sdk
         working-directory: packages/sdk
-        run: npm publish --provenance --access public
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          case "$PKG_VERSION" in
+            *-alpha*) TAG=alpha ;;
+            *-beta*)  TAG=beta ;;
+            *-rc*)    TAG=rc ;;
+            *)        TAG=latest ;;
+          esac
+          npm publish --provenance --access public --tag "$TAG"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The official TypeScript SDK for [Nuntly](https://nuntly.com), the developer-first email platform. Send transactional emails, manage domains, handle webhooks, and receive inbound mail with full type safety and zero runtime dependencies.
 
-[Documentation](https://nuntly.com/docs) | [API Reference](./api.md) | [Website](https://nuntly.com) | [Get your API key](https://app.nuntly.com/signup)
+[Documentation](https://nuntly.com/docs) | [API Reference](./api.md) | [Website](https://nuntly.com) | [Get your API key](https://nuntly.com/auth/sign-up)
 
 This repository hosts two packages:
 
@@ -61,7 +61,7 @@ The SDK has zero runtime dependencies.
 
 - Node.js 20 or later, Bun, Deno, or any modern edge runtime (Cloudflare Workers, Vercel Edge)
 - TypeScript 5.0 or later for full type inference (the SDK ships `.d.ts` and works in plain JavaScript too)
-- A Nuntly API key, available at [https://app.nuntly.com/signup](https://app.nuntly.com/signup)
+- A Nuntly API key, available at [https://nuntly.com/auth/sign-up](https://nuntly.com/auth/sign-up)
 
 ## Quick start
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -5,7 +5,7 @@
 
 The official TypeScript SDK for [Nuntly](https://nuntly.com), the developer-first email platform. Send transactional emails, manage domains, handle webhooks, and receive inbound mail with full type safety and zero runtime dependencies.
 
-[Documentation](https://nuntly.com/docs) | [API Reference](./api.md) | [Website](https://nuntly.com) | [Get your API key](https://app.nuntly.com/signup)
+[Documentation](https://nuntly.com/docs) | [API Reference](./api.md) | [Website](https://nuntly.com) | [Get your API key](https://nuntly.com/auth/sign-up)
 
 ## Table of contents
 
@@ -44,7 +44,7 @@ The SDK has zero runtime dependencies.
 
 - Node.js 20 or later, Bun, Deno, or any modern edge runtime (Cloudflare Workers, Vercel Edge)
 - TypeScript 5.0 or later for full type inference (the SDK ships `.d.ts` and works in plain JavaScript too)
-- A Nuntly API key, available at [https://app.nuntly.com/signup](https://app.nuntly.com/signup)
+- A Nuntly API key, available at [https://nuntly.com/auth/sign-up](https://nuntly.com/auth/sign-up)
 
 ## Quick start
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuntly/sdk",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
# Release Candidate v1.0.0-alpha.2

TypeScript SDK for Nuntly (`@nuntly/sdk`).

## Next step

Merge this PR, then tag `v1.0.0-alpha.2` to trigger the release workflow.

---

Generated from source `f4aa2d23174a`.