### PR TITLE
Release Candidate v1.0.0-alpha.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,11 +412,11 @@ Identifiers prefixed with `_` are internal and not subject to semver.
 
 ## Previous versions
 
-Versions `0.x` are preserved on the [`legacy/stainless-v0.x`](https://github.com/nuntly/nuntly-sdk-typescript/tree/legacy/stainless-v0.x) branch. Those releases remain installable from npm via `npm install @nuntly/sdk@0`.
+Versions `0.x` remain installable from npm via `npm install @nuntly/sdk@0` for backwards compatibility.
 
 ## Contributing
 
-Issues, bug reports, and feature requests are welcome at [github.com/nuntly/nuntly-sdk-typescript/issues](https://github.com/nuntly/nuntly-sdk-typescript/issues). The public API surface is generated from the Nuntly OpenAPI spec, so direct PRs that modify it will likely be redirected to upstream feedback. Documentation, examples, and developer-experience improvements are the highest-impact contribution areas.
+Issues, bug reports, and feature requests are welcome at [github.com/nuntly/nuntly-sdk-typescript/issues](https://github.com/nuntly/nuntly-sdk-typescript/issues).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuntly/sdk",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
# Release Candidate v1.0.0-alpha.5

TypeScript SDK for Nuntly (`@nuntly/sdk`).

## Next step

Merge this PR, then tag `v1.0.0-alpha.5` to trigger the release workflow.

---

Generated from source `8f6f4a3aa347`.