### PR TITLE
chore: temporary OIDC debug workflow

### DIFF
--- a/.github/workflows/oidc-debug.yml
+++ b/.github/workflows/oidc-debug.yml
@@ -1,0 +1,52 @@
+# Temporary investigation workflow — npm Trusted Publisher 404 on real publishes.
+# Triggers the same OIDC token request npm would receive at publish time and
+# prints the relevant claims so we can compare against the Trusted Publisher
+# config at https://www.npmjs.com/package/@nuntly/sdk/access. Removed once
+# the mismatch is identified.
+
+name: OIDC Debug
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  inspect:
+    name: Inspect OIDC claims for npm registry
+    runs-on: ubuntu-24.04
+    environment: release
+    steps:
+      - name: Fetch OIDC token and decode claims
+        run: |
+          TOKEN=$(curl -fs -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org" \
+            | jq -r '.value')
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "::error::no OIDC token returned"
+            exit 1
+          fi
+          PAYLOAD_B64=$(echo "$TOKEN" | cut -d. -f2)
+          while [ $(( ${#PAYLOAD_B64} % 4 )) -ne 0 ]; do
+            PAYLOAD_B64="${PAYLOAD_B64}="
+          done
+          echo "## OIDC claims npm sees on publish"
+          echo "$PAYLOAD_B64" | base64 -d | jq '{
+            sub,
+            aud,
+            iss,
+            repository,
+            repository_owner,
+            repository_owner_id,
+            repository_visibility,
+            workflow,
+            workflow_ref,
+            environment,
+            ref,
+            ref_type,
+            event_name,
+            actor,
+            actor_id
+          }'


### PR DESCRIPTION
Temporary investigation for the npm Trusted Publisher 404. Adds a workflow_dispatch job that prints the OIDC claims npm would see at publish time. Removed after diagnosis.