### PR TITLE
release: v1.0.0-alpha.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # npm 11.5.1+ auto-triggers the Trusted Publisher OIDC flow.
+      # Node 22 LTS ships with npm 10.x which does not, so the publish
+      # would fall back to no-auth and 404.
+      - run: npm install -g npm@latest
 
       - name: Verify tag matches package version
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuntly/sdk",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
# release: v1.0.0-alpha.9

TypeScript SDK for Nuntly (`@nuntly/sdk`).

## Next step

Merge this PR, then tag `v1.0.0-alpha.9` to trigger the release workflow.

---

commit ref `0304a56f0ce3`