### PR TITLE
docs: add MIGRATION.md for v0.x -> v1.0.0-alpha

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,124 @@
+# Migration: `v0.x` → `v1.0.0-alpha`
+
+Cheat-sheet for the 6 user-visible breaking areas. All breakage is
+intentional and will not be reversed before `1.0.0` stable.
+
+## 1. Errors are flat
+
+```ts
+// before
+catch (e) {
+  if (e instanceof APIError) {
+    e.status; e.body.status; e.body.code; e.body.title; e.body.details;
+  }
+}
+
+// after
+catch (e) {
+  if (e instanceof APIError) {
+    e.status; e.code; e.title; e.details;
+  }
+}
+```
+
+`APIErrorBody`, `Error`, `ErrorResponse` are no longer exported. If
+you typed the wire body shape explicitly, use `APIError['code']` etc.
+
+## 2. `APIPromise` for raw `Response` access
+
+```ts
+// before
+const { data, response } = await nuntly.emails.withResponse(
+  nuntly.emails.retrieve('em_123'),
+);
+
+// after
+const { data, response } = await nuntly.emails.retrieve('em_123').withResponse();
+
+// New: headers without consuming the body
+const response = await nuntly.emails.retrieve('em_123').asResponse();
+```
+
+## 3. Structured hook contexts
+
+```ts
+// before
+hooks: {
+  onRequest:  (req: Request) => ...,
+  onResponse: (res: Response, req: Request) => ...,
+  onSuccess:  (data: unknown, req: Request) => ...,
+  onError:    (err: unknown, req: Request) => ...,
+}
+
+// after
+hooks: {
+  onRequest:  (ctx) => log(ctx.method, ctx.path),
+  onResponse: (ctx) => log(ctx.request.path, ctx.response.status),
+  onSuccess:  (ctx) => log(ctx.data),
+  onError:    (ctx) => {
+    if (ctx.error instanceof APIError) log(ctx.error.status, ctx.error.code);
+  },
+}
+```
+
+`onSuccess` fires only on 2xx; `onResponse` fires on 2xx + 4xx + 5xx;
+`onError` covers 4xx/5xx + network/timeout. `ctx.error` is typed
+`APIError | APIConnectionError` — narrow with `instanceof`.
+
+## 4. Renamed response types
+
+| `v0.x` | `v1.0.0-alpha` |
+|---|---|
+| `CreateDomainResponse` | `DomainRecordsResponse` |
+| `InboxDetailResponse` | `InboxResponse` |
+
+Same wire shape; only the imported type name changes. `domains.create()`
+and `domains.retrieve()` now return the same type; same for inboxes.
+
+## 5. `PATCH` instead of `PUT` on updates
+
+The wire verb moved for two endpoints:
+
+- `PUT /api-keys/:id` → `PATCH /api-keys/:id`
+- `PUT /webhooks/:id` → `PATCH /webhooks/:id`
+
+If you call the API directly, update the verb. SDK callers
+(`nuntly.apiKeys.update(...)`, `nuntly.webhooks.update(...)`) are
+unchanged — the SDK emits `PATCH` automatically. Send at least one
+field; an empty body returns `422`.
+
+`UpdateApiKeyRequest.permission` is now optional.
+
+## 6. Event payload shape
+
+Per-event `data` is now `EmailEvent & { variant: VariantDetail }`
+instead of a 16-field inline object. Wire JSON unchanged.
+
+```ts
+// before — `data` was a giant inline (~826 chars per event)
+function handleBounce(evt: EmailBouncedEvent) {
+  evt.data.from;
+  evt.data.bounce.bounceType;
+}
+
+// after — name and reuse the envelope + variant
+import type { EmailEvent, BounceDetail } from '@nuntly/sdk';
+
+function handleBounce(data: EmailEvent & { bounce: BounceDetail }) {
+  data.from;
+  data.bounce.bounceType;
+}
+```
+
+New importable types: `EmailEvent`, `BounceDetail`, `ComplaintDetail`,
+`DeliveryDetail`, `DeliveryDelayDetail`, `OpenDetail`, `ClickDetail`,
+`RejectDetail`, `FailureDetail`, `InboundEventData`,
+`MessageRejectedEventData`.
+
+Discriminated-union narrowing on `evt.type === 'email.bounced'` keeps
+working — TypeScript projects through the intersection transparently.
+
+---
+
+Need help? Open an issue with `[migration]` in the title. Pin a
+specific alpha (`^1.0.0-alpha.12`) until `1.0.0` stable lands.


### PR DESCRIPTION
## Summary

Cheat-sheet covering the 6 user-visible breaking areas of the v1.0.0 rewrite. Aims to be scannable in 2 minutes — every section is a `// before` / `// after` pair.

## Sections

1. Errors are flat (`e.body.code` → `e.code`).
2. `APIPromise` exposes `.withResponse()` / `.asResponse()` directly on the resource method return.
3. Structured hook contexts replace positional `Request`/`Response` args.
4. `CreateDomainResponse` → `DomainRecordsResponse`, `InboxDetailResponse` → `InboxResponse`.
5. `PUT /api-keys/:id` → `PATCH /api-keys/:id`, `PUT /webhooks/:id` → `PATCH /webhooks/:id`.
6. Per-event `data` is now `EmailEvent & { variant: VariantDetail }` with importable named types.

## Length

124 lines. Tight by design — the deep dives live in the README and in the source.