### PR TITLE
release: v1.0.0-alpha.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The SDK has zero runtime dependencies.
 ## Quick start
 
 ```typescript
-import Nuntly from '@nuntly/sdk';
+import { Nuntly } from '@nuntly/sdk';
 
 const nuntly = new Nuntly({ apiKey: process.env.NUNTLY_API_KEY });
 
@@ -84,14 +84,64 @@ const nuntly = new Nuntly({
 | `logger` | `Logger` | - | Custom logger (compatible with console, pino, winston) |
 | `hooks` | `Hooks` | - | Lifecycle hooks (see [Lifecycle hooks](#lifecycle-hooks)) |
 | `fetch` | `typeof fetch` | `globalThis.fetch` | Custom fetch implementation |
+| `defaultHeaders` | `Record<string, string>` | - | Headers sent on every request (tenant id, telemetry, proxy auth). Overridden by per-request `headers`. |
+
+### Multi-tenant and client cloning
+
+Real-world problems `defaultHeaders` and `withOptions(partial)` solve:
+
+**Problem: each customer in your SaaS has their own Nuntly API key.**
+Building a new `Nuntly` per request loses hooks, retry config, and the warm fetch pool.
+
+```typescript
+const root = new Nuntly({ apiKey: process.env.NUNTLY_API_KEY });
+
+// Per-tenant client, reuses the root config except apiKey
+const tenant = root.withOptions({ apiKey: tenantApiKey });
+await tenant.emails.send({ from, to, subject, html });
+```
+
+**Problem: an inbound request in your app fans out to several services (DB, Stripe, Nuntly...). You want one trace ID across all of them.**
+Forward your trace ID on every Nuntly call so your APM correlates the outbound email send with the inbound request that triggered it.
+
+```typescript
+const traced = root.withOptions({
+  defaultHeaders: { 'X-Trace-Id': req.traceId },
+});
+await traced.emails.send({ from, to, subject, html });
+```
+
+**Problem: audit/compliance team needs to know "which user in our app sent this email".**
+Stamp `X-Initiated-By` on every request. Your gateway / proxy / log pipeline records it; Nuntly itself ignores it.
+
+```typescript
+const audited = root.withOptions({
+  defaultHeaders: { 'X-Initiated-By': `user:${userId}` },
+});
+```
+
+**Problem: your CI/staging environment runs behind a corporate egress proxy that requires auth.**
+
+```typescript
+const corpClient = new Nuntly({
+  apiKey: process.env.NUNTLY_API_KEY,
+  defaultHeaders: { 'Proxy-Authorization': `Basic ${process.env.PROXY_TOKEN}` },
+});
+```
+
+#### Mental model
+
+- `withOptions(partial)` returns a **new** client. The original instance is untouched, hooks and retry config are reused. `defaultHeaders` is deep-merged; the rest of the options is shallow-replaced.
+- `defaultHeaders` is **passthrough**: the SDK sets them on every HTTP request, but Nuntly does not parse or route on them. The value lives in your own observability, proxy, and audit chain.
 
 ## Pagination
 
-List methods return a `CursorPage` with auto-pagination:
+List methods return a `PagePromise` that you can either `await` for a
+single `CursorPage` or iterate with `for await` to auto-paginate:
 
 ```typescript
 // Auto-paginate all items
-for await (const email of await nuntly.emails.list({ limit: 10 })) {
+for await (const email of nuntly.emails.list({ limit: 10 })) {
   console.log(email.id);
 }
 
@@ -136,7 +186,7 @@ try {
 
 Error classes: `BadRequestError` (400), `AuthenticationError` (401), `PermissionDeniedError` (403), `NotFoundError` (404), `ConflictError` (409), `UnprocessableEntityError` (422), `RateLimitError` (429), `InternalServerError` (5xx).
 
-Every error exposes `status`, `body`, `headers`, `requestId`, and `rawResponse`.
+Every error exposes `status`, `code`, `title`, `details`, `headers`, `requestId`, and `rawResponse`.
 
 ## Webhook verification
 
@@ -200,28 +250,34 @@ const { data, error } = await safe(nuntly).emails.retrieve('em_123');
 
 ## Lifecycle hooks
 
-Hook into the HTTP lifecycle for logging, telemetry, or auth refresh:
+Hook into the HTTP lifecycle for logging, telemetry, or auth refresh. Every
+hook receives a single structured `ctx` argument:
 
 ```typescript
 import type { Hooks } from '@nuntly/sdk';
+import { APIError } from '@nuntly/sdk';
 
 const nuntly = new Nuntly({
   apiKey: process.env.NUNTLY_API_KEY,
   hooks: {
-    onRequest: (request) => {
-      console.log(`-> ${request.method} ${request.url}`);
+    onRequest: (ctx) => {
+      console.log(`-> ${ctx.method} ${ctx.url}`);
     },
-    onResponse: (response, request) => {
-      console.log(`<- ${response.status} (${response.headers.get('x-request-id')})`);
+    onResponse: (ctx) => {
+      console.log(`<- ${ctx.response.status} ${ctx.request.path}`);
     },
-    onSuccess: (data, request) => {
+    onSuccess: (ctx) => {
       metrics.increment('api.success');
     },
-    onRetry: ({ attempt, response }) => {
-      console.warn(`Retry #${attempt}, status: ${response?.status}`);
+    onRetry: (ctx) => {
+      console.warn(`Retry #${ctx.attempt} ${ctx.request.path}`);
     },
-    onError: (error, request) => {
-      sentry.captureException(error);
+    onError: (ctx) => {
+      if (ctx.error instanceof APIError) {
+        sentry.captureException(ctx.error, { tags: { code: ctx.error.code } });
+      } else {
+        sentry.captureException(ctx.error);
+      }
     },
   },
 });
@@ -229,13 +285,16 @@ const nuntly = new Nuntly({
 
 | Hook | Signature | When |
 |------|-----------|------|
-| `onRequest` | `(request: Request) => void` | Before each HTTP request |
-| `onResponse` | `(response: Response, request: Request) => void` | After final response (post-retry) |
-| `onSuccess` | `(data: unknown, request: Request) => void` | After successful response parsing |
-| `onRetry` | `(context: RetryContext) => void` | Before each retry attempt |
-| `onError` | `(error: unknown, request: Request) => void` | On any error |
+| `onRequest` | `(ctx: RequestContext) => void \| Promise<void>` | Before each HTTP request |
+| `onResponse` | `(ctx: ResponseContext) => void \| Promise<void>` | After each HTTP response (2xx, 4xx, 5xx); not called on network errors |
+| `onSuccess` | `(ctx: SuccessContext) => void \| Promise<void>` | After each 2xx response, with the parsed payload |
+| `onRetry` | `(ctx: RetryContext) => void \| Promise<void>` | Before each retry attempt |
+| `onError` | `(ctx: ErrorContext) => void \| Promise<void>` | On 4xx/5xx (`APIError`) or network/timeout (`APIConnectionError`) |
 
-All hooks support async (return `Promise<void>`).
+Per-request invocation order on the happy path:
+`onRequest -> [onRetry x N] -> onResponse -> (onSuccess | onError)`.
+
+All hooks may return a `Promise<void>` and are awaited by the client.
 
 ## Retry configuration
 
@@ -270,7 +329,7 @@ The SDK automatically respects `Retry-After` headers on 429 responses.
 
 ## Raw response access
 
-Every resource method returns an `APIPromise<T>` — a `Promise<T>` you can
+Every resource method returns an `APIPromise<T>`. It is a `Promise<T>` you can
 `await` as usual, with two extra methods for accessing the raw `Response`.
 
 Use `.withResponse()` when you need both the parsed data and the
@@ -301,9 +360,16 @@ console.log(response.status, response.headers.get('x-request-id'));
 await nuntly.emails.send(payload, {
   timeout: 30000,
   maxRetries: 0,
-  headers: { 'X-Idempotency-Key': 'unique-key-123' },
+  idempotencyKey: 'unique-key-123',
 });
 ```
+
+The wire header is `Idempotency-Key` (no `X-` prefix). The SDK auto-generates
+a UUID v4 for `emails.send`, `emails.bulk.send`, `messages.reply`,
+`messages.forward`, and `inboxes.messages.send` when `idempotencyKey` is not
+provided. Pass an explicit value to wire up your own retry key (e.g. for
+cross-process deduplication). You can also set the header manually via
+`headers: { 'Idempotency-Key': '...' }` if you prefer.
 
 ### Abort a request
 

--- a/api.md
+++ b/api.md
@@ -85,7 +85,7 @@ Create or update the memory for an AI agent.
 
 ### `apiKeys.create(body: CreateApiKeyRequest, options?: RequestOptions)`
 
-Generate a new API key. The key value is only returned once — store it securely.
+Generate a new API key. The key value is only returned once. Store it securely.
 
 - **HTTP**: `POST /api-keys`
 - **Returns**: `CreateApiKeyResponse`
@@ -183,7 +183,7 @@ Update the key name, permissions, or restrict it to specific sending domains.
 
 ### `domains.create(body: CreateDomainRequest, options?: RequestOptions)`
 
-Add a domain to start configuring DNS records for sending or receiving emails.
+Add a domain for sending or receiving emails.
 
 - **HTTP**: `POST /domains`
 - **Returns**: `DomainRecordsResponse`
@@ -402,7 +402,7 @@ Send transactional emails through Nuntly platform. It supports HTML and plain-te
 
 ### `emails.bulk.list(bulkId: string, options?: RequestOptions)`
 
-Returns the delivery status of all emails submitted in a bulk request.
+Returns the emails submitted in a bulk request.
 
 - **HTTP**: `GET /emails/bulk/{bulkId}`
 - **Returns**: `BulkEmailsResponse`
@@ -459,7 +459,7 @@ Returns presigned URLs to download the HTML, plain-text, and raw MIME source of 
 
 ### `emails.events.list(id: string, options?: RequestOptions)`
 
-Returns the full delivery event history for an email (sent, delivered, opened, bounced, etc.).
+Returns the delivery event history for an email (sent, delivered, opened, bounced, etc.).
 
 - **HTTP**: `GET /emails/{id}/events`
 - **Returns**: `EmailEventsResponse`
@@ -940,21 +940,6 @@ List inboxes in a namespace.
 
 ## organizations
 
-### `organizations.retrieve(id: string, options?: RequestOptions)`
-
-Returns the organization's profile, plan, region, and account status.
-
-- **HTTP**: `GET /organizations/{id}`
-- **Returns**: `OrganizationResponse`
-
-**OrganizationResponse**
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | `string` | The id of the organization |
-| `name` | `string` | The name of the organization |
-| `status` | `'enabled' | 'disabled'` | The status of the organization |
-
 ### `organizations.list(query?: CursorPageParams, options?: RequestOptions)`
 
 Returns all organizations the authenticated user belongs to.
@@ -964,6 +949,21 @@ Returns all organizations the authenticated user belongs to.
 - **Paginated**: yes
 
 **OrganizationsResponseItem**
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | `string` | The id of the organization |
+| `name` | `string` | The name of the organization |
+| `status` | `'enabled' | 'disabled'` | The status of the organization |
+
+### `organizations.retrieve(id: string, options?: RequestOptions)`
+
+Returns the organization's profile, plan, region, and account status.
+
+- **HTTP**: `GET /organizations/{id}`
+- **Returns**: `OrganizationResponse`
+
+**OrganizationResponse**
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuntly/sdk",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/src/core/api-promise.ts
+++ b/src/core/api-promise.ts
@@ -1,3 +1,4 @@
+import type { CursorPage } from './pagination.js';
 import type { ResponseWithData } from './types.js';
 
 /**
@@ -11,9 +12,9 @@ export class APIPromise<T> extends Promise<T> {
     return Promise;
   }
 
-  private readonly responsePromise: Promise<Response>;
+  protected readonly responsePromise: Promise<Response>;
 
-  private constructor(
+  protected constructor(
     executor: (
       resolve: (value: T | PromiseLike<T>) => void,
       reject: (reason: unknown) => void,
@@ -44,5 +45,26 @@ export class APIPromise<T> extends Promise<T> {
 
   map<U>(fn: (value: T) => U): APIPromise<U> {
     return APIPromise.fromPromises((this as Promise<T>).then(fn), this.responsePromise);
+  }
+}
+
+export class PagePromise<TPage extends CursorPage<TItem>, TItem>
+  extends APIPromise<TPage>
+  implements AsyncIterable<TItem>
+{
+  static fromPagePromises<TPage extends CursorPage<TItem>, TItem>(
+    dataPromise: Promise<TPage>,
+    responsePromise: Promise<Response>,
+  ): PagePromise<TPage, TItem> {
+    return new PagePromise<TPage, TItem>((resolve, reject) => {
+      dataPromise.then(resolve, reject);
+    }, responsePromise);
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<TItem> {
+    const firstPage = await (this as Promise<TPage>);
+    for await (const item of firstPage) {
+      yield item;
+    }
   }
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,5 +1,5 @@
 import { up } from 'up-fetch';
-import { APIPromise } from './api-promise.js';
+import { APIPromise, PagePromise } from './api-promise.js';
 import { APIError, APIConnectionError, APIConnectionTimeoutError } from './error.js';
 import { CursorPage } from './pagination.js';
 import type {
@@ -148,6 +148,10 @@ export class NuntlyClient {
     const fetchFn = (options.fetch ?? globalThis.fetch) as typeof fetch;
 
     const headers: Record<string, string> = {
+      // User-supplied `defaultHeaders` come first so Authorization / User-Agent
+      // (set below) always override them. Per-request `RequestOptions.headers`
+      // is applied later by up-fetch and wins over everything here.
+      ...options.defaultHeaders,
       Authorization: `Bearer ${self.apiKey}`,
     };
     if (!isBrowserLike()) {
@@ -280,18 +284,22 @@ export class NuntlyClient {
     return this.request<T>({ method: 'DELETE', ...args });
   }
 
-  async list<T>(args: {
+  list<T>(args: {
     path: string;
     pathParams?: Record<string, unknown>;
     query?: Record<string, unknown>;
     options?: RequestOptions;
-  }): Promise<CursorPage<T>> {
+  }): PagePromise<CursorPage<T>, T> {
     const params: CursorPageParams = (args.query as CursorPageParams) ?? {};
-    const response = await this.get<CursorPageResponse<T>>(args);
-    return new CursorPage<T>(
-      response,
-      params,
-      (nextParams) => this.get<CursorPageResponse<T>>({ ...args, query: nextParams as Record<string, unknown> }),
-    );
+    const firstResponse = this.get<CursorPageResponse<T>>(args);
+    const pagePromise = (async () => {
+      const response = await firstResponse;
+      return new CursorPage<T>(
+        response,
+        params,
+        (nextParams) => this.get<CursorPageResponse<T>>({ ...args, query: nextParams as Record<string, unknown> }),
+      );
+    })();
+    return PagePromise.fromPagePromises<CursorPage<T>, T>(pagePromise, firstResponse.asResponse());
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,7 +1,7 @@
 export { NuntlyClient } from './client.js';
 export { Resource } from './resource.js';
 export { CursorPage } from './pagination.js';
-export { APIPromise } from './api-promise.js';
+export { APIPromise, PagePromise } from './api-promise.js';
 export { safe } from './safe.js';
 export type { SafeResult } from './safe.js';
 

--- a/src/core/safe.ts
+++ b/src/core/safe.ts
@@ -1,6 +1,8 @@
-import type { APIError } from './error.js';
+import type { APIError, APIConnectionError } from './error.js';
 
-export type SafeResult<T> = { data: T; error: null } | { data: null; error: APIError };
+export type SafeResult<T> =
+  | { data: T; error: null }
+  | { data: null; error: APIError | APIConnectionError };
 
 type Safeify<T> = {
   [K in keyof T]: T[K] extends (...args: infer A) => Promise<infer R>

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -24,7 +24,7 @@ export interface ResponseContext {
   response: Response;
 }
 
-export interface SuccessContext<T = any> {
+export interface SuccessContext<T = unknown> {
   request: RequestContext;
   response: Response;
   data: T;
@@ -104,6 +104,12 @@ export interface ClientOptions {
    * or replace it, only append to it.
    */
   appInfo?: AppInfo;
+  /**
+   * Headers sent on every request. Merged with per-request `RequestOptions.headers`
+   * (per-request wins on conflict). Useful for tenant-id forwarding, telemetry
+   * (e.g. `X-Trace-Id`), or corporate proxy auth.
+   */
+  defaultHeaders?: Record<string, string>;
 }
 
 export interface RequestOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { Webhooks } from './resources/webhooks/index.js';
 
 export class Nuntly {
   private readonly client: NuntlyClient;
+  private readonly options: ClientOptions;
 
   readonly agents: Agents;
   readonly apiKeys: ApiKeys;
@@ -28,6 +29,7 @@ export class Nuntly {
   readonly webhooks: Webhooks;
 
   constructor(options: ClientOptions) {
+    this.options = options;
     this.client = new NuntlyClient(options);
     this.agents = new Agents(this.client);
     this.apiKeys = new ApiKeys(this.client);
@@ -40,6 +42,22 @@ export class Nuntly {
     this.threads = new Threads(this.client);
     this.webhooks = new Webhooks(this.client);
   }
+
+  /**
+   * Returns a new Nuntly client with the supplied options merged on top of the
+   * original. `defaultHeaders` is merged deeply (later headers win on conflict).
+   *
+   * @example
+   * const tenantClient = nuntly.withOptions({ apiKey: tenantApiKey });
+   * await tenantClient.emails.send({ ... });
+   */
+  withOptions(partial: Partial<ClientOptions>): Nuntly {
+    return new Nuntly({
+      ...this.options,
+      ...partial,
+      defaultHeaders: { ...this.options.defaultHeaders, ...partial.defaultHeaders },
+    });
+  }
 }
 
 export function createSafeNuntly(options: ClientOptions) {
@@ -47,8 +65,9 @@ export function createSafeNuntly(options: ClientOptions) {
 }
 
 export { NuntlyClient, safe } from './core/index.js';
+export { APIPromise, PagePromise } from './core/index.js';
 export type { SafeResult } from './core/index.js';
-export type { AppInfo, Logger, Hooks, RetryContext, BackoffStrategy, RetryStrategy, ClientOptions, RequestOptions, ResponseWithData, CursorPageResponse, CursorPageParams } from './core/index.js';
+export type { AppInfo, Logger, Hooks, RequestContext, ResponseContext, SuccessContext, ErrorContext, RetryContext, BackoffStrategy, RetryStrategy, ClientOptions, RequestOptions, ResponseWithData, CursorPageResponse, CursorPageParams } from './core/index.js';
 export {
   NuntlyError,
   APIError,

--- a/src/lib/webhook.ts
+++ b/src/lib/webhook.ts
@@ -65,8 +65,8 @@ export async function verifyWebhook(
     throw new WebhookVerificationError('Invalid timestamp');
   }
   const age = Math.floor(Date.now() / 1000) - ts;
-  if (age > tolerance) {
-    throw new WebhookVerificationError('Webhook timestamp is too old');
+  if (Math.abs(age) > tolerance) {
+    throw new WebhookVerificationError('Webhook timestamp outside tolerance window');
   }
 
   const candidates = parts

--- a/src/resources/api-keys/index.ts
+++ b/src/resources/api-keys/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import type { ApiKeyResponse, ApiKeysResponseItem, CreateApiKeyRequest, CreateApiKeyResponse, DeleteApiKeyResponse, UpdateApiKeyRequest, UpdateApiKeyResponse } from '../types.js';
 
 
@@ -9,7 +9,7 @@ import type { ApiKeyResponse, ApiKeysResponseItem, CreateApiKeyRequest, CreateAp
 export class ApiKeys extends Resource {
 
   /**
-   * Generate a new API key. The key value is only returned once — store it securely.
+   * Generate a new API key. The key value is only returned once. Store it securely.
    *
    * POST /api-keys
    * @param body - CreateApiKeyRequest
@@ -46,9 +46,9 @@ export class ApiKeys extends Resource {
    * GET /api-keys
    * @param query - CursorPageParams
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<ApiKeysResponseItem>>
+   * @returns PagePromise<CursorPage<ApiKeysResponseItem>, ApiKeysResponseItem>
    */
-  async list(query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<ApiKeysResponseItem>> {
+  list(query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<ApiKeysResponseItem>, ApiKeysResponseItem> {
     return this._http.list<ApiKeysResponseItem>({
       path: '/api-keys',
       query: query as unknown as Record<string, unknown>,

--- a/src/resources/domains/index.ts
+++ b/src/resources/domains/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import type { CreateDomainRequest, DeleteDomainResponse, DomainRecordsResponse, DomainsResponseItem, UpdateDomainRequest, UpdateDomainResponse } from '../types.js';
 
 
@@ -9,7 +9,7 @@ import type { CreateDomainRequest, DeleteDomainResponse, DomainRecordsResponse, 
 export class Domains extends Resource {
 
   /**
-   * Add a domain to start configuring DNS records for sending or receiving emails.
+   * Add a domain for sending or receiving emails.
    *
    * POST /domains
    * @param body - CreateDomainRequest
@@ -46,9 +46,9 @@ export class Domains extends Resource {
    * GET /domains
    * @param query - CursorPageParams
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<DomainsResponseItem>>
+   * @returns PagePromise<CursorPage<DomainsResponseItem>, DomainsResponseItem>
    */
-  async list(query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<DomainsResponseItem>> {
+  list(query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<DomainsResponseItem>, DomainsResponseItem> {
     return this._http.list<DomainsResponseItem>({
       path: '/domains',
       query: query as unknown as Record<string, unknown>,

--- a/src/resources/emails/bulk/index.ts
+++ b/src/resources/emails/bulk/index.ts
@@ -10,7 +10,7 @@ import type { BulkEmailsResponse, CreateBulkEmailsRequest, CreateBulkEmailsRespo
 export class EmailsBulk extends Resource {
 
   /**
-   * Returns the delivery status of all emails submitted in a bulk request.
+   * Returns the emails submitted in a bulk request.
    *
    * GET /emails/bulk/{bulkId}
    * @param bulkId - string

--- a/src/resources/emails/events/index.ts
+++ b/src/resources/emails/events/index.ts
@@ -9,7 +9,7 @@ import type { EmailEventsResponse } from '../../types.js';
 export class EmailsEvents extends Resource {
 
   /**
-   * Returns the full delivery event history for an email (sent, delivered, opened, bounced, etc.).
+   * Returns the delivery event history for an email (sent, delivered, opened, bounced, etc.).
    *
    * GET /emails/{id}/events
    * @param id - string

--- a/src/resources/emails/index.ts
+++ b/src/resources/emails/index.ts
@@ -1,6 +1,6 @@
 import { Resource } from '../../core/index.js';
 import type { NuntlyClient } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import { generateIdempotencyKey } from '../../lib/idempotency.js';
 import type { CreateEmailRequest, CreateEmailResponse, DeleteEmailResponse, EmailResponse, EmailsResponseItem } from '../types.js';
 
@@ -48,9 +48,9 @@ export class Emails extends Resource {
    * GET /emails
    * @param query - CursorPageParams
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<EmailsResponseItem>>
+   * @returns PagePromise<CursorPage<EmailsResponseItem>, EmailsResponseItem>
    */
-  async list(query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<EmailsResponseItem>> {
+  list(query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<EmailsResponseItem>, EmailsResponseItem> {
     return this._http.list<EmailsResponseItem>({
       path: '/emails',
       query: query as unknown as Record<string, unknown>,

--- a/src/resources/inboxes/index.ts
+++ b/src/resources/inboxes/index.ts
@@ -1,6 +1,6 @@
 import { Resource } from '../../core/index.js';
 import type { NuntlyClient } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import type { CreateInboxRequest, IdResponse, InboxResponse, InboxesQuery, InboxesResponseItem, UpdateInboxRequest } from '../types.js';
 
 import { InboxesMessages } from './messages/index.js';
@@ -57,9 +57,9 @@ export class Inboxes extends Resource {
    * GET /inboxes
    * @param query - InboxesQuery
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<InboxesResponseItem>>
+   * @returns PagePromise<CursorPage<InboxesResponseItem>, InboxesResponseItem>
    */
-  async list(query?: InboxesQuery, options?: RequestOptions): Promise<CursorPage<InboxesResponseItem>> {
+  list(query?: InboxesQuery, options?: RequestOptions): PagePromise<CursorPage<InboxesResponseItem>, InboxesResponseItem> {
     return this._http.list<InboxesResponseItem>({
       path: '/inboxes',
       query: query as unknown as Record<string, unknown>,

--- a/src/resources/inboxes/messages/index.ts
+++ b/src/resources/inboxes/messages/index.ts
@@ -1,5 +1,6 @@
 import { Resource } from '../../../core/index.js';
 import type { APIPromise, RequestOptions } from '../../../core/index.js';
+import { generateIdempotencyKey } from '../../../lib/idempotency.js';
 import type { SendMessageRequest, SendMessageResponse } from '../../types.js';
 
 
@@ -18,6 +19,8 @@ export class InboxesMessages extends Resource {
    * @returns APIPromise<SendMessageResponse>
    */
   send(inboxId: string, body: SendMessageRequest, options?: RequestOptions): APIPromise<SendMessageResponse> {
+    const idempotencyKey = options?.idempotencyKey ?? generateIdempotencyKey();
+    options = { ...options, headers: { 'Idempotency-Key': idempotencyKey, ...options?.headers } };
     return this._http.post<{ data: SendMessageResponse }>({
       path: '/inboxes/{inboxId}/messages',
       pathParams: { inboxId },

--- a/src/resources/inboxes/threads/index.ts
+++ b/src/resources/inboxes/threads/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../../core/index.js';
 import type { ThreadsQuery, ThreadsResponseItem } from '../../types.js';
 
 
@@ -15,9 +15,9 @@ export class InboxesThreads extends Resource {
    * @param inboxId - string
    * @param query - ThreadsQuery
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<ThreadsResponseItem>>
+   * @returns PagePromise<CursorPage<ThreadsResponseItem>, ThreadsResponseItem>
    */
-  async list(inboxId: string, query?: ThreadsQuery, options?: RequestOptions): Promise<CursorPage<ThreadsResponseItem>> {
+  list(inboxId: string, query?: ThreadsQuery, options?: RequestOptions): PagePromise<CursorPage<ThreadsResponseItem>, ThreadsResponseItem> {
     return this._http.list<ThreadsResponseItem>({
       path: '/inboxes/{inboxId}/threads',
       pathParams: { inboxId },

--- a/src/resources/messages/index.ts
+++ b/src/resources/messages/index.ts
@@ -1,6 +1,7 @@
 import { Resource } from '../../core/index.js';
 import type { NuntlyClient } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
+import { generateIdempotencyKey } from '../../lib/idempotency.js';
 import type { ForwardMessageRequest, IdResponse, MessageResponse, MessagesQuery, MessagesResponseItem, ReplyMessageRequest, SendMessageResponse, UpdateMessageRequest } from '../types.js';
 
 import { MessagesAttachments } from './attachments/index.js';
@@ -29,6 +30,8 @@ export class Messages extends Resource {
    * @returns APIPromise<SendMessageResponse>
    */
   forward(messageId: string, body: ForwardMessageRequest, options?: RequestOptions): APIPromise<SendMessageResponse> {
+    const idempotencyKey = options?.idempotencyKey ?? generateIdempotencyKey();
+    options = { ...options, headers: { 'Idempotency-Key': idempotencyKey, ...options?.headers } };
     return this._http.post<{ data: SendMessageResponse }>({
       path: '/messages/{messageId}/forward',
       pathParams: { messageId },
@@ -43,9 +46,9 @@ export class Messages extends Resource {
    * GET /messages
    * @param query - MessagesQuery
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<MessagesResponseItem>>
+   * @returns PagePromise<CursorPage<MessagesResponseItem>, MessagesResponseItem>
    */
-  async list(query?: MessagesQuery, options?: RequestOptions): Promise<CursorPage<MessagesResponseItem>> {
+  list(query?: MessagesQuery, options?: RequestOptions): PagePromise<CursorPage<MessagesResponseItem>, MessagesResponseItem> {
     return this._http.list<MessagesResponseItem>({
       path: '/messages',
       query: query as unknown as Record<string, unknown>,
@@ -63,6 +66,8 @@ export class Messages extends Resource {
    * @returns APIPromise<SendMessageResponse>
    */
   reply(messageId: string, body: ReplyMessageRequest, options?: RequestOptions): APIPromise<SendMessageResponse> {
+    const idempotencyKey = options?.idempotencyKey ?? generateIdempotencyKey();
+    options = { ...options, headers: { 'Idempotency-Key': idempotencyKey, ...options?.headers } };
     return this._http.post<{ data: SendMessageResponse }>({
       path: '/messages/{messageId}/reply',
       pathParams: { messageId },

--- a/src/resources/namespaces/inboxes/index.ts
+++ b/src/resources/namespaces/inboxes/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../../core/index.js';
 import type { InboxesResponseItem, NamespaceInboxesQuery } from '../../types.js';
 
 
@@ -15,9 +15,9 @@ export class NamespacesInboxes extends Resource {
    * @param namespaceId - string
    * @param query - NamespaceInboxesQuery
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<InboxesResponseItem>>
+   * @returns PagePromise<CursorPage<InboxesResponseItem>, InboxesResponseItem>
    */
-  async list(namespaceId: string, query?: NamespaceInboxesQuery, options?: RequestOptions): Promise<CursorPage<InboxesResponseItem>> {
+  list(namespaceId: string, query?: NamespaceInboxesQuery, options?: RequestOptions): PagePromise<CursorPage<InboxesResponseItem>, InboxesResponseItem> {
     return this._http.list<InboxesResponseItem>({
       path: '/namespaces/{namespaceId}/inboxes',
       pathParams: { namespaceId },

--- a/src/resources/namespaces/index.ts
+++ b/src/resources/namespaces/index.ts
@@ -1,6 +1,6 @@
 import { Resource } from '../../core/index.js';
 import type { NuntlyClient } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import type { CreateNamespaceRequest, IdResponse, NamespaceDetail, NamespaceResponse, NamespacesQuery, NamespacesResponseItem, UpdateNamespaceRequest } from '../types.js';
 
 import { NamespacesInboxes } from './inboxes/index.js';
@@ -54,9 +54,9 @@ export class Namespaces extends Resource {
    * GET /namespaces
    * @param query - NamespacesQuery
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<NamespacesResponseItem>>
+   * @returns PagePromise<CursorPage<NamespacesResponseItem>, NamespacesResponseItem>
    */
-  async list(query?: NamespacesQuery, options?: RequestOptions): Promise<CursorPage<NamespacesResponseItem>> {
+  list(query?: NamespacesQuery, options?: RequestOptions): PagePromise<CursorPage<NamespacesResponseItem>, NamespacesResponseItem> {
     return this._http.list<NamespacesResponseItem>({
       path: '/namespaces',
       query: query as unknown as Record<string, unknown>,

--- a/src/resources/organizations/index.ts
+++ b/src/resources/organizations/index.ts
@@ -1,6 +1,6 @@
 import { Resource } from '../../core/index.js';
 import type { NuntlyClient } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import type { OrganizationResponse, OrganizationsResponseItem } from '../types.js';
 
 import { OrganizationsUsage } from './usage/index.js';
@@ -17,6 +17,22 @@ export class Organizations extends Resource {
   }
 
   /**
+   * Returns all organizations the authenticated user belongs to.
+   *
+   * GET /organizations
+   * @param query - CursorPageParams
+   * @param options - RequestOptions
+   * @returns PagePromise<CursorPage<OrganizationsResponseItem>, OrganizationsResponseItem>
+   */
+  list(query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<OrganizationsResponseItem>, OrganizationsResponseItem> {
+    return this._http.list<OrganizationsResponseItem>({
+      path: '/organizations',
+      query: query as unknown as Record<string, unknown>,
+      options,
+    });
+  }
+
+  /**
    * Returns the organization's profile, plan, region, and account status.
    *
    * GET /organizations/{id}
@@ -30,22 +46,6 @@ export class Organizations extends Resource {
       pathParams: { id },
       options,
     }).map((r) => r.data);
-  }
-
-  /**
-   * Returns all organizations the authenticated user belongs to.
-   *
-   * GET /organizations
-   * @param query - CursorPageParams
-   * @param options - RequestOptions
-   * @returns Promise<CursorPage<OrganizationsResponseItem>>
-   */
-  async list(query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<OrganizationsResponseItem>> {
-    return this._http.list<OrganizationsResponseItem>({
-      path: '/organizations',
-      query: query as unknown as Record<string, unknown>,
-      options,
-    });
   }
 
 }

--- a/src/resources/threads/messages/index.ts
+++ b/src/resources/threads/messages/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../../core/index.js';
 import type { ThreadMessagesResponseItem } from '../../types.js';
 
 
@@ -15,9 +15,9 @@ export class ThreadsMessages extends Resource {
    * @param threadId - string
    * @param query - CursorPageParams
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<ThreadMessagesResponseItem>>
+   * @returns PagePromise<CursorPage<ThreadMessagesResponseItem>, ThreadMessagesResponseItem>
    */
-  async list(threadId: string, query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<ThreadMessagesResponseItem>> {
+  list(threadId: string, query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<ThreadMessagesResponseItem>, ThreadMessagesResponseItem> {
     return this._http.list<ThreadMessagesResponseItem>({
       path: '/threads/{threadId}/messages',
       pathParams: { threadId },

--- a/src/resources/webhooks/events/index.ts
+++ b/src/resources/webhooks/events/index.ts
@@ -1,5 +1,5 @@
 import { Resource } from '../../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../../core/index.js';
 import type { WebhookEventDeliveriesResponse, WebhookEventsResponseItem } from '../../types.js';
 
 
@@ -31,9 +31,9 @@ export class WebhooksEvents extends Resource {
    * GET /webhooks/events
    * @param query - CursorPageParams
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<WebhookEventsResponseItem>>
+   * @returns PagePromise<CursorPage<WebhookEventsResponseItem>, WebhookEventsResponseItem>
    */
-  async list(query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<WebhookEventsResponseItem>> {
+  list(query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<WebhookEventsResponseItem>, WebhookEventsResponseItem> {
     return this._http.list<WebhookEventsResponseItem>({
       path: '/webhooks/events',
       query: query as unknown as Record<string, unknown>,

--- a/src/resources/webhooks/index.ts
+++ b/src/resources/webhooks/index.ts
@@ -1,6 +1,6 @@
 import { Resource } from '../../core/index.js';
 import type { NuntlyClient } from '../../core/index.js';
-import type { APIPromise, RequestOptions, CursorPage, CursorPageParams } from '../../core/index.js';
+import type { APIPromise, RequestOptions, CursorPage, CursorPageParams, PagePromise } from '../../core/index.js';
 import type { CreateWebhookRequest, CreateWebhookResponse, DeleteWebhookResponse, UpdateWebhookRequest, UpdateWebhookResponse, WebhookResponse, WebhooksResponseItem } from '../types.js';
 
 import { WebhooksEvents } from './events/index.js';
@@ -54,9 +54,9 @@ export class Webhooks extends Resource {
    * GET /webhooks
    * @param query - CursorPageParams
    * @param options - RequestOptions
-   * @returns Promise<CursorPage<WebhooksResponseItem>>
+   * @returns PagePromise<CursorPage<WebhooksResponseItem>, WebhooksResponseItem>
    */
-  async list(query?: CursorPageParams, options?: RequestOptions): Promise<CursorPage<WebhooksResponseItem>> {
+  list(query?: CursorPageParams, options?: RequestOptions): PagePromise<CursorPage<WebhooksResponseItem>, WebhooksResponseItem> {
     return this._http.list<WebhooksResponseItem>({
       path: '/webhooks',
       query: query as unknown as Record<string, unknown>,

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -325,6 +325,42 @@ describe("Pagination", () => {
 		expect(items).toHaveLength(2);
 		expect(callCount).toBe(2);
 	});
+
+	it("for await directly on list() result auto-paginates", async () => {
+		// Regression: previously `client.emails.list()` was `async` and returned
+		// a bare `Promise<CursorPage>`, which made `for await (const x of list())`
+		// silently yield nothing. `PagePromise` makes the call site work without
+		// an extra `await`.
+		let callCount = 0;
+		const nuntly = createClient((req) => {
+			callCount++;
+			const url = new URL(req.url);
+			const cursor = url.searchParams.get("cursor");
+			if (!cursor) {
+				return jsonResponse({ data: [{ id: "em_1" }], nextCursor: "page2" });
+			}
+			return jsonResponse({ data: [{ id: "em_2" }], nextCursor: null });
+		});
+
+		const items: unknown[] = [];
+		for await (const item of nuntly.emails.list({ limit: 1 })) {
+			items.push(item);
+		}
+		expect(items).toHaveLength(2);
+		expect(callCount).toBe(2);
+	});
+
+	it("list() result supports .withResponse() like APIPromise", async () => {
+		const nuntly = createClient(() =>
+			jsonResponse({ data: [{ id: "em_1" }], nextCursor: null }),
+		);
+
+		const { data: page, response } = await nuntly.emails
+			.list()
+			.withResponse();
+		expect(page.data).toHaveLength(1);
+		expect(response.status).toBe(200);
+	});
 });
 
 describe("Auth and headers", () => {
@@ -448,7 +484,15 @@ describe("Webhook verification", () => {
 		const old = Math.floor(Date.now() / 1000) - 10 * 60;
 		const header = await buildHeader(eventPayload, secret, old);
 		await expect(verifyWebhook(eventPayload, header, secret)).rejects.toThrow(
-			"too old",
+			"outside tolerance window",
+		);
+	});
+
+	it("rejects a future timestamp (replay attack guard)", async () => {
+		const future = Math.floor(Date.now() / 1000) + 10 * 60;
+		const header = await buildHeader(eventPayload, secret, future);
+		await expect(verifyWebhook(eventPayload, header, secret)).rejects.toThrow(
+			"outside tolerance window",
 		);
 	});
 
@@ -471,7 +515,7 @@ describe("Webhook verification", () => {
 		// 30s tolerance: 60s old should fail
 		await expect(
 			verifyWebhook(eventPayload, header, secret, { tolerance: 30 }),
-		).rejects.toThrow("too old");
+		).rejects.toThrow("outside tolerance window");
 		// 120s tolerance: 60s old should pass
 		const event = await verifyWebhook(eventPayload, header, secret, { tolerance: 120 });
 		expect(event.type).toBe("email.delivered");
@@ -733,5 +777,94 @@ describe("Hooks", () => {
 
 		await nuntly.emails.retrieve("em_1");
 		expect(retries).toEqual([1]);
+	});
+});
+
+describe("defaultHeaders and withOptions", () => {
+	it("sends defaultHeaders on every request", async () => {
+		const captured: Headers[] = [];
+		const nuntly = new Nuntly({
+			apiKey: "test_key",
+			baseUrl: "https://api.test.com",
+			defaultHeaders: { "X-Tenant-Id": "tenant_42", "X-Trace-Id": "trace_1" },
+			fetch: mockFetch((req) => {
+				captured.push(req.headers);
+				return jsonResponse({ data: { id: "em_1" } });
+			}) as typeof fetch,
+		});
+
+		await nuntly.emails.retrieve("em_1");
+		await nuntly.emails.send(emailPayload);
+
+		expect(captured.length).toBe(2);
+		expect(captured[0]!.get("x-tenant-id")).toBe("tenant_42");
+		expect(captured[0]!.get("x-trace-id")).toBe("trace_1");
+		expect(captured[1]!.get("x-tenant-id")).toBe("tenant_42");
+		expect(captured[1]!.get("x-trace-id")).toBe("trace_1");
+	});
+
+	it("per-request headers override defaultHeaders", async () => {
+		let captured: Headers | null = null;
+		const nuntly = new Nuntly({
+			apiKey: "test_key",
+			baseUrl: "https://api.test.com",
+			defaultHeaders: { "X-Tenant-Id": "tenant_default" },
+			fetch: mockFetch((req) => {
+				captured = req.headers;
+				return jsonResponse({ data: { id: "em_1" } });
+			}) as typeof fetch,
+		});
+
+		await nuntly.emails.retrieve("em_1", {
+			headers: { "X-Tenant-Id": "tenant_override" },
+		});
+		expect(captured!.get("x-tenant-id")).toBe("tenant_override");
+	});
+
+	it("withOptions returns a new Nuntly with merged options", async () => {
+		let capturedKey: string | null = null;
+		const fetchImpl = mockFetch((req) => {
+			capturedKey = req.headers.get("authorization");
+			return jsonResponse({ data: { id: "em_1" } });
+		}) as typeof fetch;
+
+		const root = new Nuntly({
+			apiKey: "root_key",
+			baseUrl: "https://api.test.com",
+			fetch: fetchImpl,
+		});
+		const tenant = root.withOptions({ apiKey: "tenant_key" });
+
+		// The original is not mutated.
+		expect(root).not.toBe(tenant);
+
+		await tenant.emails.retrieve("em_1");
+		expect(capturedKey).toBe("Bearer tenant_key");
+
+		await root.emails.retrieve("em_1");
+		expect(capturedKey).toBe("Bearer root_key");
+	});
+
+	it("withOptions deep-merges defaultHeaders", async () => {
+		let captured: Headers | null = null;
+		const fetchImpl = mockFetch((req) => {
+			captured = req.headers;
+			return jsonResponse({ data: { id: "em_1" } });
+		}) as typeof fetch;
+
+		const root = new Nuntly({
+			apiKey: "root_key",
+			baseUrl: "https://api.test.com",
+			defaultHeaders: { "X-Service": "billing", "X-Region": "eu1" },
+			fetch: fetchImpl,
+		});
+		const tenant = root.withOptions({
+			defaultHeaders: { "X-Tenant-Id": "tenant_42", "X-Region": "us1" },
+		});
+
+		await tenant.emails.retrieve("em_1");
+		expect(captured!.get("x-service")).toBe("billing"); // inherited
+		expect(captured!.get("x-tenant-id")).toBe("tenant_42"); // added
+		expect(captured!.get("x-region")).toBe("us1"); // overridden
 	});
 });


### PR DESCRIPTION
# v1.0.0-alpha.14

### Breaking changes

- Renamed `GET /organizations` (`"retrieve-organizations"` → `"list-organizations"`)

### Changed

- `create-api-key`: description updated
- `create-domain`: description updated
- `retrieve-bulk-emails`: description updated
- `retrieve-email-events`: description updated

source `b06f2f397bcd`